### PR TITLE
Handle development database fallback

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,31 @@
+# Remote-Team Mental Health Tracker configuration example
+# Copy this file to `.env` and adjust values as needed.
+
+# Application environment: dev, prod, or test
+APP_ENV=dev
+
+# Secrets used for session signing and admin API authentication
+SECRET_KEY=dev-secret-key-change-me
+RMHT_ADMIN_TOKEN=dev-admin-token-change-me
+
+# Optional in development. Required when APP_ENV=prod.
+# DATABASE_URL=postgresql+psycopg2://user:password@hostname:5432/database
+
+# When DATABASE_URL is omitted in development, a local SQLite database file
+# will be created at ./rmht.db. Set SQLITE_DATABASE_PATH to override.
+# SQLITE_DATABASE_PATH=rmht.db
+
+# Configure allowed origins for CORS. Comma-separated list.
+ALLOWED_CORS_ORIGINS=*
+
+# Third-party integrations (all optional)
+# SENDGRID_API_KEY=
+# SLACK_CLIENT_ID=
+# SLACK_CLIENT_SECRET=
+# STRIPE_SECRET_KEY=
+# STRIPE_WEBHOOK_SECRET=
+# STRIPE_PRICE_STARTER=
+# STRIPE_PRICE_PRO=
+# STRIPE_PRICE_ENTERPRISE=
+# APP_BASE_URL=
+# CRON_SECRET=

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ __pycache__/
 *.pyc
 .env
 .env.*
+!.env.example
 .venv/
 venv/
 .rmht_secret*

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ pip install -r requirements.txt
 
 # copy and edit environment
 cp .env.example .env
-# update DATABASE_URL, SECRET_KEY, etc.
+# update secrets as needed. DATABASE_URL is optional in dev and defaults to SQLite.
 
 # run migrations
 alembic upgrade head
@@ -59,7 +59,7 @@ python scripts/import_sqlite.py
 
 | Variable | Purpose |
 | --- | --- |
-| `DATABASE_URL` | Postgres connection string (`postgresql+psycopg2://...`) |
+| `DATABASE_URL` | Postgres connection string (`postgresql+psycopg2://...`). Optional when `APP_ENV=dev` (uses SQLite fallback). |
 | `SECRET_KEY` | HMAC secret for JWT magic links and sessions |
 | `RMHT_ADMIN_TOKEN` | Legacy token for scripting (admins now use magic links) |
 | `SENDGRID_API_KEY` | SendGrid API key for passwordless emails |
@@ -69,6 +69,7 @@ python scripts/import_sqlite.py
 | `STRIPE_PRICE_*` | Price IDs for Starter/Pro/Enterprise plans |
 | `APP_BASE_URL` | Public base URL used in links and Slack prompts |
 | `CRON_SECRET` | Shared secret for Railway cron job endpoints |
+| `SQLITE_DATABASE_PATH` | Override path for the dev SQLite fallback (defaults to `rmht.db`) |
 
 ## Key routes
 

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -16,7 +16,7 @@ if config.config_file_name is not None:
     fileConfig(config.config_file_name)
 
 settings = get_settings()
-config.set_main_option("sqlalchemy.url", settings.database_url)
+config.set_main_option("sqlalchemy.url", settings.resolved_database_url)
 
 target_metadata = Base.metadata
 

--- a/app/db/session.py
+++ b/app/db/session.py
@@ -10,7 +10,15 @@ from sqlalchemy.orm import sessionmaker
 from app.core.config import get_settings
 
 settings = get_settings()
-engine = create_engine(settings.database_url, pool_pre_ping=True, future=True)
+database_url = settings.resolved_database_url
+connect_args = {"check_same_thread": False} if database_url.startswith("sqlite") else {}
+
+engine = create_engine(
+    database_url,
+    pool_pre_ping=True,
+    future=True,
+    connect_args=connect_args,
+)
 SessionLocal = sessionmaker(bind=engine, autocommit=False, autoflush=False, future=True)
 
 

--- a/replit.md
+++ b/replit.md
@@ -66,3 +66,11 @@ Preferred communication style: Simple, everyday language.
 ### Optional Services
 - **HRIS Integration**: Placeholder for employee roster synchronization
 - **Calendar Integration**: Placeholder for meeting utilization analytics
+
+## Replit deployment notes
+
+- Set `APP_ENV=dev`, `SECRET_KEY`, and `RMHT_ADMIN_TOKEN` in the Secrets panel.
+- Leave `DATABASE_URL` unset for development; the app will automatically create `rmht.db` using SQLite.
+- Provide `DATABASE_URL` and production-grade secrets when switching `APP_ENV` to `prod`.
+- Run `uvicorn app.main:app --host 0.0.0.0 --port 8000` to start the service.
+

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,42 @@
+"""Configuration behaviour smoke tests."""
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+import pytest
+from pydantic import ValidationError
+
+from app.core.config import Settings
+
+
+def test_dev_uses_sqlite_fallback(monkeypatch, tmp_path):
+    """Development mode should fall back to SQLite when DATABASE_URL is absent."""
+
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.setenv("APP_ENV", "dev")
+    sqlite_path = tmp_path / "dev.db"
+    monkeypatch.setenv("SQLITE_DATABASE_PATH", str(sqlite_path))
+
+    settings = Settings()
+
+    expected_url = f"sqlite:///{sqlite_path}"
+    assert settings.resolved_database_url == expected_url
+    assert settings.sqlite_database_path == Path(str(sqlite_path))
+
+
+def test_prod_requires_database_url(monkeypatch):
+    """Production must fail fast when DATABASE_URL is missing."""
+
+    monkeypatch.setenv("APP_ENV", "prod")
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.setenv("SECRET_KEY", "super-secret-key")
+    monkeypatch.setenv("RMHT_ADMIN_TOKEN", "super-admin-token")
+    monkeypatch.setenv("ALLOWED_CORS_ORIGINS", "[\"https://example.com\"]")
+
+    with pytest.raises(ValidationError):
+        Settings()


### PR DESCRIPTION
## Summary
- allow configuration to default to SQLite in development while keeping production strict about DATABASE_URL
- update SQLAlchemy engine, Alembic, and startup logging to use the resolved connection string safely
- document the new behavior with an `.env.example`, README and Replit notes, and add config smoke tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca1ae9e5f88333a5c0d96c02e09e07